### PR TITLE
Removed start() override in TwilioBackend to comply with new BackendBase.start()

### DIFF
--- a/rtwilio/outgoing.py
+++ b/rtwilio/outgoing.py
@@ -8,10 +8,6 @@ from rapidsms.backends.base import BackendBase
 class TwilioBackend(BackendBase):
     """A RapidSMS backend for Twilio (http://www.twilio.com/)."""
 
-    def start(self):
-        """Override BackendBase.start(), which never returns."""
-        self._running = True
-
     def configure(self, config=None, **kwargs):
         self.config = config
         self.client = TwilioRestClient(self.config['account_sid'],


### PR DESCRIPTION
This is in reference to issue 174 in rapidsms/rapidsms at https://github.com/rapidsms/rapidsms/issues/174
