### PR TITLE
More Flexiable Twilio Requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     install_requires=(
         'rapidsms>=0.13.0',
         'django>=1.4',
-        'twilio==3.5.1',
+        'twilio>=3.5,<4.0',
     ),
     test_suite="runtests.runtests",
 )


### PR DESCRIPTION
Remove pinning `twilio` requirement to a single bug fix release. Looking through their release notes the minor versions note new features/API endpoints added rather than backwards incompatible changes. I think it is safe to allow any version up until there is another major release (4.0). 