### PR TITLE
Twilio Validation

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2007-2013, Caktus Consulting Group, LLC
+Copyright (c) 2007-2015, Caktus Consulting Group, LLC
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'rapidsms-twilio'
-copyright = u'2013, Caktus Consulting Group, LLC'
+copyright = u'2007-2015, Caktus Consulting Group, LLC'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -27,6 +27,7 @@ Add the following to your existing ``INSTALLED_BACKENDS`` configuration in your
                 'account_sid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',  # (required)
                 'auth_token': 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY',  # (required)
                 'number': '(###) ###-####',  # your Twilio phone number (required)
+                'validate': True,  # Require Twilio signature on all requests
                 # 'callback': 'http://<public-django-instance>/twilio/status-callback/',  # optional callback URL
             }
         },

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,11 +4,17 @@ Release History
 Release and change history for rapidsms-twilio
 
 
-v1.0.0 (Released TBD)
+v0.2.1 (Released 2015-03-27)
 ----------------------------
+
+Security release to add support for validating incoming requests from Twilio. For
+backwards compatibility this is not enabled by default. You should update your backend
+configuration to include the new ``validate`` configuration. See the quick-start for
+an example configuration.
 
 * Improved ``tox`` testing support for RapidSMS and Django version combinations.
 * Relaxed ``twilio`` requirement.
+* Added Twilio request signature validation.
 
 
 v0.2.0 (Released 2013-06-21)
@@ -24,7 +30,7 @@ Improved callback functionality and added needed tests:
 Bug Fixes
 _________
 
-- Fixed issue where using a port with the callbark URL caused an error.
+- Fixed issue where using a port with the callback URL caused an error.
 
 
 v0.1.0 (Released 2013-06-10)

--- a/rtwilio/__init__.py
+++ b/rtwilio/__init__.py
@@ -1,4 +1,4 @@
 "Twilio backend for the RapidSMS project."
 
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/rtwilio/tests/test_views.py
+++ b/rtwilio/tests/test_views.py
@@ -2,7 +2,8 @@ from mock import Mock, patch
 
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-from django.test import TestCase, RequestFactory, override_settings
+from django.test import TestCase, RequestFactory
+from django.test.utils import override_settings
 
 from rapidsms.tests.harness import RapidTest, CreateDataMixin
 

--- a/rtwilio/tests/test_views.py
+++ b/rtwilio/tests/test_views.py
@@ -1,18 +1,32 @@
-from mock import Mock
+from mock import Mock, patch
 
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
-from django.test import TestCase, RequestFactory
+from django.test import TestCase, RequestFactory, override_settings
 
 from rapidsms.tests.harness import RapidTest, CreateDataMixin
 
 from ..views import validate_twilio_signature
 
 
+EXAMPLE_CONFIG = {
+    'ENGINE': 'rtwilio.outgoing.TwilioBackend',
+    'config': {
+        'account_sid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+        'auth_token': 'YYYYYYYYYYYYYYYYYYYYYYYYYY',
+        'number': '(###) ###-####',
+        'validate': False,
+    }
+}
+
+
 class TwilioViewTest(RapidTest):
 
     urls = 'rtwilio.tests.urls'
     disable_phases = True
+    backends = {
+        'twilio-backend': EXAMPLE_CONFIG,
+    }
 
     def test_invalid_response(self):
         """HTTP 400 should return if data is invalid."""
@@ -45,6 +59,7 @@ class TwilioViewTest(RapidTest):
         self.assertEqual('rtwilio-backend', message.connection.backend.name)
 
 
+@override_settings(INSTALLED_BACKENDS={'twilio-backend': EXAMPLE_CONFIG})
 class CallbackTest(CreateDataMixin, TestCase):
 
     urls = 'rtwilio.tests.urls'
@@ -104,6 +119,7 @@ class SignatureValidationTestCase(TestCase):
                 'account_sid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
                 'auth_token': '12345',
                 'number': '(###) ###-####',
+                'validate': True,
             }
         }
         self.view = Mock()

--- a/rtwilio/tests/test_views.py
+++ b/rtwilio/tests/test_views.py
@@ -101,7 +101,7 @@ class SignatureValidationTestCase(TestCase):
         self.factory = RequestFactory()
         # From http://www.twilio.com/docs/security example
         self.request = self.factory.post(
-            'myapp.php?foo=1&bar=2',
+            '/myapp.php?foo=1&bar=2',
             {
                 'CallSid': 'CA1234567890ABCDE',
                 'Caller': '+14158675309',

--- a/rtwilio/views.py
+++ b/rtwilio/views.py
@@ -1,16 +1,46 @@
+import functools
 import logging
 
+from django.conf import settings
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.utils.decorators import available_attrs
 from django.views.decorators.http import require_POST
 from django.views.decorators.csrf import csrf_exempt
 
 from rapidsms.backends.http.views import GenericHttpBackendView
+from twilio.util import RequestValidator
 
 from rtwilio.models import TwilioResponse
 from rtwilio.forms import StatusCallbackForm, TwilioForm
 
 
 logger = logging.getLogger(__name__)
+
+
+def validate_twilio_signature(func=None, backend_name='twilio-backend'):
+    """View decorator to validate requests from Twilio per http://www.twilio.com/docs/security."""
+
+    def _dec(view_func):
+        @functools.wraps(view_func, assigned=available_attrs(view_func))
+        def _wrapped_view(request, *args, **kwargs):
+            backend = kwargs.get('backend_name', backend_name)
+            config = settings.INSTALLED_BACKENDS[backend]['config']
+            validator = RequestValidator(config['auth_token'])
+            signature = request.META.get('HTTP_X_TWILIO_SIGNATURE', '')
+            url = request.build_absolute_uri()
+            body = {}
+            if request.method == 'POST':
+                body = request.POST
+            if validator.validate(url, body, signature):
+                return view_func(request, *args, **kwargs)
+            else:
+                return HttpResponseBadRequest()
+        return _wrapped_view
+
+    if func is None:
+        return _dec
+    else:
+        return _dec(func)
 
 
 class TwilioBackendView(GenericHttpBackendView):

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = {py27}-dj{14,15,16,17}-rsms{13,14,15,16,17,18,19}
 basepython =
     py27: python2.7
 deps =
+    mock>=1.0,<1.1
     dj14: django>=1.4,<1.5
     dj15: django>=1.5,<1.6
     dj16: django>=1.6,<1.7


### PR DESCRIPTION
Closes a long standing security issue where the incoming requests from Twilio were not validated against the signature. This remains off by default my plan was to release v0.2.1 with that fix and then follow up with a v0.3 today which turns the validation on by default. Not sure how I feel about having the option to turn it off but it does help with the unittesting.