### PR TITLE
Enable Twilio request validation by Default

### DIFF
--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -27,7 +27,6 @@ Add the following to your existing ``INSTALLED_BACKENDS`` configuration in your
                 'account_sid': 'ACXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',  # (required)
                 'auth_token': 'YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY',  # (required)
                 'number': '(###) ###-####',  # your Twilio phone number (required)
-                'validate': True,  # Require Twilio signature on all requests
                 # 'callback': 'http://<public-django-instance>/twilio/status-callback/',  # optional callback URL
             }
         },

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -4,6 +4,19 @@ Release History
 Release and change history for rapidsms-twilio
 
 
+v0.3.0 (Released 2015-03-27)
+----------------------------
+
+This is a minor release following up on the previous security release to turn the
+request validation on by default.
+
+
+Backwards Incompatible Changes
+______________________________
+
+* Twilio validation is now enforced by default. To turn this off you can set ``validate`` to ``False`` in your backend configuration. This is not recommended.
+
+
 v0.2.1 (Released 2015-03-27)
 ----------------------------
 

--- a/rtwilio/__init__.py
+++ b/rtwilio/__init__.py
@@ -1,4 +1,4 @@
 "Twilio backend for the RapidSMS project."
 
 
-__version__ = '0.2.1'
+__version__ = '0.3.0'

--- a/rtwilio/views.py
+++ b/rtwilio/views.py
@@ -31,7 +31,7 @@ def validate_twilio_signature(func=None, backend_name='twilio-backend'):
             body = {}
             if request.method == 'POST':
                 body = request.POST
-            require_validation = config.get('validate', False)
+            require_validation = config.get('validate', True)
             if validator.validate(url, body, signature) or not require_validation:
                 return view_func(request, *args, **kwargs)
             else:


### PR DESCRIPTION
Another minor release to enable the validation by default which is potentially backwards incompatible.