### PR TITLE
Travis Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,18 @@
 language: python
 
+sudo: false
+
+cache:
+  directories:
+    - ~/.cache/pip
+
 python:
   - "2.7"
 
 env:
   - TOXENV=py27-dj17-rsms18,py27-dj17-rsms19
   - TOXENV=py27-dj18-rsms18,py27-dj18-rsms19
+  - TOXENV=flake
 
 install:
   - pip install -q "tox>=1.8,<2.0"

--- a/rtwilio/outgoing.py
+++ b/rtwilio/outgoing.py
@@ -1,6 +1,6 @@
 import pprint
 import logging
-import datetime
+
 from twilio.rest import TwilioRestClient
 
 from rapidsms.backends.base import BackendBase

--- a/rtwilio/tests/test_views.py
+++ b/rtwilio/tests/test_views.py
@@ -1,4 +1,4 @@
-from mock import Mock, patch
+from mock import Mock
 
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length=100
+exclude=migrations

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
 [flake8]
 max-line-length=100
 exclude=migrations
+
+[bdist_wheel]
+universal = 1

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27}-dj{17,18}-rsms{18,19}
+envlist = {py27}-dj{17,18}-rsms{18,19},flake
 
 [testenv]
 basepython =
@@ -11,3 +11,8 @@ deps =
     rsms18: rapidsms>=0.18,<0.19
     rsms19: rapidsms>=0.19,<0.20
 commands = {envpython} setup.py test {posargs}
+
+[testenv:flake]
+basepython = python2.7
+deps = flake8
+commands = flake8 rtwilio


### PR DESCRIPTION
Added universal wheel support. Next release can be uploaded via `python setup.py sdist bdist_wheel upload`. Added caching, Docker support on Travis though I'm not sure that works on the open source version. Added flake8 checks as well. Fixes #15.