### PR TITLE
Prep for Python 3

### DIFF
--- a/rtwilio/tests/test_views.py
+++ b/rtwilio/tests/test_views.py
@@ -1,4 +1,7 @@
-from mock import Mock
+try:
+    from unittest.mock import Mock
+except ImportError:
+    from mock import Mock
 
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse

--- a/rtwilio/tests/test_views.py
+++ b/rtwilio/tests/test_views.py
@@ -56,7 +56,7 @@ class TwilioViewTest(RapidTest):
         message = self.inbound[0]
         self.assertEqual(data['Body'], message.text)
         self.assertEqual(message.fields['external_id'], data['SmsSid'])
-        self.assertEqual('twilio-backend', message.connection.backend.name)
+        self.assertEqual('twilio-backend', message.connections[0].backend.name)
 
 
 @override_settings(

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ deps =
     dj18: django>=1.8,<1.9
     rsms18: rapidsms>=0.18,<0.19
     rsms19: rapidsms>=0.19,<0.20
-commands = {envpython} setup.py test {posargs}
+commands = {envpython} -Wall setup.py test {posargs}
 
 [testenv:flake]
 basepython = python2.7

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,17 @@
 [tox]
-envlist = {py27}-dj{17,18}-rsms{18,19},flake
+envlist = {py27}-dj{17,18}-rsms{18,19},{py33}-dj{17,18}-rsms{20},flake
 
 [testenv]
 basepython =
     py27: python2.7
+    py33: python3.3
 deps =
     py27: mock>=1.0,<1.1
     dj17: django>=1.7,<1.8
     dj18: django>=1.8,<1.9
     rsms18: rapidsms>=0.18,<0.19
     rsms19: rapidsms>=0.19,<0.20
+    rsms20: https://github.com/rapidsms/rapidsms/archive/feature/python-3-support.zip
 commands = {envpython} -Wall setup.py test {posargs}
 
 [testenv:flake]


### PR DESCRIPTION
Cleaned up a deprecation warning for future versions of RapidSMS and started testing on Python 3.3. 1.0 still probably shouldn't be released until RapidSMS 0.20 (or whatever they are going to call it) but looks like we will be ready.